### PR TITLE
Fix undefined hook issue

### DIFF
--- a/src/publisher/react-devtools-hook.ts
+++ b/src/publisher/react-devtools-hook.ts
@@ -155,7 +155,7 @@ export function installReactDevtoolsHook(
 ) {
   const existingHook = target[hookName];
 
-  if (target.hasOwnProperty(hookName)) {
+  if (existingHook && target.hasOwnProperty(hookName)) {
     if (existingHook[MARKER] === MARKER) {
       return existingHook;
     }


### PR DESCRIPTION
hasOwnProperty() can return true even when the property itself is undefined which causes an erroneous behavior.